### PR TITLE
Remove "wholemodule" from SWIFT_OPTIMIZATION_LEVEL

### DIFF
--- a/Base/Configurations/Debug.xcconfig
+++ b/Base/Configurations/Debug.xcconfig
@@ -44,7 +44,7 @@ SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG
 // final installation location
 STRIP_INSTALLED_PRODUCT = NO
 
-// The optimization level (-Onone, -O, -Ofast) for the produced Swift binary
+// The optimization level (-Onone, -O, -Osize) for the produced Swift binary
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 
 // Disable Developer ID timestamping

--- a/Base/Configurations/Release.xcconfig
+++ b/Base/Configurations/Release.xcconfig
@@ -29,10 +29,11 @@ ONLY_ACTIVE_ARCH = NO
 // final installation location
 STRIP_INSTALLED_PRODUCT = YES
 
-// The optimization level (-Onone, -O, -Owholemodule) for the produced Swift binary
-SWIFT_OPTIMIZATION_LEVEL = -Owholemodule
+// The optimization level (-Onone, -O, -Osize) for the produced Swift binary
+SWIFT_OPTIMIZATION_LEVEL = -O
 
 // Introduced in Xcode 9.3 - No documentation yet
+// singlefile or wholemodule
 SWIFT_COMPILATION_MODE = wholemodule
 
 // Whether to perform App Store validation checks


### PR DESCRIPTION
The compilation mode (single-file or whole-module) has a separate setting as of Xcode 9.3 (SWIFT_COMPILATION_MODE)