### PR TITLE
Support SwiftUI previews in frameworks that depend on other non-system frameworks

### DIFF
--- a/Base/Targets/Framework.xcconfig
+++ b/Base/Targets/Framework.xcconfig
@@ -31,6 +31,13 @@ INSTALL_PATH = @rpath
 LD_DYLIB_INSTALL_NAME = @rpath/$(PRODUCT_NAME).$(WRAPPER_EXTENSION)/$(PRODUCT_NAME)
 SKIP_INSTALL = YES
 
+// Make SwiftUI previews work in frameworks that depend on other non-system 
+// frameworks. The Xcode agent that renders SwiftUI previews seems to copy all
+// required frameworks from the built product into a single temp directory.
+// This allows the rendering agent to find the frameworks there.
+// Source: https://github.com/NSHipster/articles/issues/673
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @loader_path/..
+
 // Disallows use of APIs that are not available
 // to app extensions and linking to frameworks
 // that have not been built with this setting enabled.


### PR DESCRIPTION
The Xcode agent that renders SwiftUI previews seems to copy all required frameworks from the built product into a single temp directory. This allows the rendering agent to find the frameworks there.

Source: https://github.com/NSHipster/articles/issues/673